### PR TITLE
Update .config

### DIFF
--- a/router-config/openwrt-21.02/.config
+++ b/router-config/openwrt-21.02/.config
@@ -448,6 +448,7 @@ CONFIG_BRCMFMAC_SDIO=y
 CONFIG_BRCMFMAC_USB=y
 
 # LuCI-app:
+CONFIG_PACKAGE_luci-app-openclash=y
 # CONFIG_PACKAGE_luci-app-acl is not set
 CONFIG_PACKAGE_luci-app-acme=y
 # CONFIG_PACKAGE_luci-app-adblock is not set


### PR DESCRIPTION
#==================================================================================
# https://github.com/ophub/amlogic-s9xxx-openwrt
# Description: Automatically Build OpenWrt for Amlogic S9xxx STB
# Source code repository: https://github.com/openwrt/openwrt / Branch: 21.02
#==================================================================================

# Build Firmware:
CONFIG_TARGET_armvirt=y
CONFIG_TARGET_armvirt_64=y
CONFIG_TARGET_armvirt_64_Default=y

# Firmware Type:
CONFIG_USES_DEVICETREE=y
CONFIG_USES_INITRAMFS=y
CONFIG_USES_SQUASHFS=y
CONFIG_USES_EXT4=y
CONFIG_USES_TARGZ=y
CONFIG_USES_CPIOGZ=y
CONFIG_ARCH_64BIT=y
CONFIG_VIRTIO_SUPPORT=y
CONFIG_PCI_SUPPORT=y
CONFIG_USB_SUPPORT=y
CONFIG_aarch64=y
CONFIG_ARCH="aarch64"
CONFIG_LINUX_5_4=y
CONFIG_DEFAULT_base-files=y
CONFIG_DEFAULT_busybox=y

# Target and Root filesystem Images:
CONFIG_TARGET_ROOTFS_INITRAMFS=y
CONFIG_TARGET_INITRAMFS_COMPRESSION_NONE=y
# CONFIG_TARGET_INITRAMFS_COMPRESSION_GZIP is not set
# CONFIG_TARGET_INITRAMFS_COMPRESSION_BZIP2 is not set
# CONFIG_TARGET_INITRAMFS_COMPRESSION_LZMA is not set
# CONFIG_TARGET_INITRAMFS_COMPRESSION_LZO is not set
# CONFIG_TARGET_INITRAMFS_COMPRESSION_LZ4 is not set
# CONFIG_TARGET_INITRAMFS_COMPRESSION_XZ is not set
CONFIG_EXTERNAL_CPIO=""
# CONFIG_TARGET_INITRAMFS_FORCE is not set
# CONFIG_TARGET_ROOTFS_CPIOGZ is not set
CONFIG_TARGET_ROOTFS_TARGZ=y
# CONFIG_TARGET_ROOTFS_EXT4FS is not set
# CONFIG_TARGET_ROOTFS_SQUASHFS is not set
CONFIG_TARGET_UBIFS_FREE_SPACE_FIXUP=y
CONFIG_TARGET_UBIFS_JOURNAL_SIZE=""
# CONFIG_TARGET_IMAGES_GZIP is not set
# CONFIG_EXPERIMENTAL is not set

# Translations
# CONFIG_LUCI_LANG_ar is not set
# CONFIG_LUCI_LANG_bg is not set
# CONFIG_LUCI_LANG_bn_BD is not set
# CONFIG_LUCI_LANG_ca is not set
# CONFIG_LUCI_LANG_cs is not set
# CONFIG_LUCI_LANG_de is not set
# CONFIG_LUCI_LANG_el is not set
CONFIG_LUCI_LANG_en=y
# CONFIG_LUCI_LANG_es is not set
# CONFIG_LUCI_LANG_fi is not set
# CONFIG_LUCI_LANG_fr is not set
# CONFIG_LUCI_LANG_he is not set
# CONFIG_LUCI_LANG_hi is not set
# CONFIG_LUCI_LANG_hu is not set
# CONFIG_LUCI_LANG_it is not set
# CONFIG_LUCI_LANG_ja is not set
# CONFIG_LUCI_LANG_ko is not set
# CONFIG_LUCI_LANG_mr is not set
# CONFIG_LUCI_LANG_ms is not set
# CONFIG_LUCI_LANG_nb_NO is not set
# CONFIG_LUCI_LANG_nl is not set
# CONFIG_LUCI_LANG_pl is not set
# CONFIG_LUCI_LANG_pt is not set
# CONFIG_LUCI_LANG_pt_BR is not set
# CONFIG_LUCI_LANG_ro is not set
# CONFIG_LUCI_LANG_ru is not set
# CONFIG_LUCI_LANG_sk is not set
# CONFIG_LUCI_LANG_sv is not set
# CONFIG_LUCI_LANG_tr is not set
# CONFIG_LUCI_LANG_uk is not set
# CONFIG_LUCI_LANG_vi is not set
CONFIG_LUCI_LANG_zh_Hans=y
# CONFIG_LUCI_LANG_zh_Hant is not set

# National language packs, luci-i18n-base:
# CONFIG_PACKAGE_luci-i18n-base-ar is not set
# CONFIG_PACKAGE_luci-i18n-base-bg is not set
# CONFIG_PACKAGE_luci-i18n-base-bn is not set
# CONFIG_PACKAGE_luci-i18n-base-ca is not set
# CONFIG_PACKAGE_luci-i18n-base-cs is not set
# CONFIG_PACKAGE_luci-i18n-base-de is not set
# CONFIG_PACKAGE_luci-i18n-base-el is not set
CONFIG_PACKAGE_luci-i18n-base-en=y
# CONFIG_PACKAGE_luci-i18n-base-es is not set
# CONFIG_PACKAGE_luci-i18n-base-fi is not set
# CONFIG_PACKAGE_luci-i18n-base-fr is not set
# CONFIG_PACKAGE_luci-i18n-base-he is not set
# CONFIG_PACKAGE_luci-i18n-base-hi is not set
# CONFIG_PACKAGE_luci-i18n-base-hu is not set
# CONFIG_PACKAGE_luci-i18n-base-it is not set
# CONFIG_PACKAGE_luci-i18n-base-ja is not set
# CONFIG_PACKAGE_luci-i18n-base-ko is not set
# CONFIG_PACKAGE_luci-i18n-base-mr is not set
# CONFIG_PACKAGE_luci-i18n-base-ms is not set
# CONFIG_PACKAGE_luci-i18n-base-nl is not set
# CONFIG_PACKAGE_luci-i18n-base-no is not set
# CONFIG_PACKAGE_luci-i18n-base-pl is not set
# CONFIG_PACKAGE_luci-i18n-base-pt is not set
# CONFIG_PACKAGE_luci-i18n-base-pt-br is not set
# CONFIG_PACKAGE_luci-i18n-base-ro is not set
# CONFIG_PACKAGE_luci-i18n-base-ru is not set
# CONFIG_PACKAGE_luci-i18n-base-sk is not set
# CONFIG_PACKAGE_luci-i18n-base-sv is not set
# CONFIG_PACKAGE_luci-i18n-base-tr is not set
# CONFIG_PACKAGE_luci-i18n-base-uk is not set
# CONFIG_PACKAGE_luci-i18n-base-vi is not set
CONFIG_PACKAGE_luci-i18n-base-zh-cn=y
# CONFIG_PACKAGE_luci-i18n-base-zh-tw is not set
CONFIG_PACKAGE_luci-i18n-amlogic-en=y
CONFIG_PACKAGE_luci-i18n-amlogic-zh-cn=y

# Firmware:
CONFIG_PACKAGE_brcmfmac-firmware-4329-sdio=y
CONFIG_PACKAGE_brcmfmac-firmware-43362-sdio=y
CONFIG_PACKAGE_brcmfmac-firmware-43430-sdio=y
CONFIG_PACKAGE_brcmfmac-firmware-43430-sdio-rpi-3b=y
CONFIG_PACKAGE_brcmfmac-firmware-43430-sdio-rpi-zero-w=y
CONFIG_PACKAGE_brcmfmac-firmware-43430a0-sdio=y
CONFIG_PACKAGE_brcmfmac-firmware-43455-sdio=y
CONFIG_PACKAGE_brcmfmac-firmware-43455-sdio-rpi-3b-plus=y
CONFIG_PACKAGE_brcmfmac-firmware-43455-sdio-rpi-4b=y
CONFIG_PACKAGE_brcmfmac-firmware-usb=y
CONFIG_PACKAGE_carl9170-firmware=y
CONFIG_PACKAGE_cypress-firmware-4339-sdio=y
CONFIG_PACKAGE_edgeport-firmware=y
CONFIG_PACKAGE_mt7601u-firmware=y
CONFIG_PACKAGE_p54-usb-firmware=y
CONFIG_PACKAGE_rs9113-firmware=y
CONFIG_PACKAGE_rt2800-usb-firmware=y
CONFIG_PACKAGE_rt73-usb-firmware=y
CONFIG_PACKAGE_rtl8188eu-firmware=y
CONFIG_PACKAGE_rtl8192cu-firmware=y
CONFIG_PACKAGE_rtl8192eu-firmware=y
CONFIG_PACKAGE_rtl8192su-firmware=y
CONFIG_PACKAGE_rtl8723au-firmware=y
CONFIG_PACKAGE_rtl8723bs-firmware=y
CONFIG_PACKAGE_rtl8723bu-firmware=y
CONFIG_PACKAGE_wireless-regdb=y

# Wireless Drivers:
# CONFIG_PACKAGE_kmod-adm8211 is not set
# CONFIG_PACKAGE_kmod-ar5523 is not set
CONFIG_PACKAGE_kmod-ath=y
CONFIG_ATH_USER_REGD=y
# CONFIG_PACKAGE_ATH_DEBUG is not set
CONFIG_PACKAGE_ATH_DFS=y
# CONFIG_PACKAGE_ATH_DYNACK is not set
CONFIG_PACKAGE_kmod-ath10k=y
CONFIG_ATH10K_LEDS=y
# CONFIG_ATH10K_THERMAL is not set
# CONFIG_PACKAGE_kmod-ath10k-ct is not set
# CONFIG_PACKAGE_kmod-ath10k-ct-smallbuffers is not set
# CONFIG_PACKAGE_kmod-ath5k is not set
CONFIG_PACKAGE_kmod-ath6kl=y
# CONFIG_PACKAGE_kmod-ath6kl-sdio is not set
CONFIG_PACKAGE_kmod-ath6kl-usb=y
# CONFIG_PACKAGE_kmod-ath9k is not set
CONFIG_PACKAGE_kmod-ath9k-common=y
CONFIG_PACKAGE_kmod-ath9k-htc=y
# CONFIG_PACKAGE_kmod-b43 is not set
# CONFIG_PACKAGE_kmod-b43legacy is not set
CONFIG_PACKAGE_kmod-brcmfmac=y
CONFIG_BRCMFMAC_SDIO=y
CONFIG_BRCMFMAC_USB=y
# CONFIG_BRCMFMAC_PCIE is not set
# CONFIG_PACKAGE_kmod-brcmsmac is not set
CONFIG_PACKAGE_kmod-brcmutil=y
# CONFIG_PACKAGE_BRCM80211_DEBUG is not set
CONFIG_PACKAGE_kmod-carl9170=y
CONFIG_PACKAGE_kmod-cfg80211=y
# CONFIG_PACKAGE_CFG80211_TESTMODE is not set
# CONFIG_PACKAGE_kmod-hermes is not set
# CONFIG_PACKAGE_kmod-hermes-pci is not set
# CONFIG_PACKAGE_kmod-hermes-plx is not set
# CONFIG_PACKAGE_kmod-ipw2100 is not set
# CONFIG_PACKAGE_kmod-ipw2200 is not set
# CONFIG_PACKAGE_kmod-iwl-legacy is not set
# CONFIG_PACKAGE_kmod-iwl3945 is not set
# CONFIG_PACKAGE_kmod-iwl4965 is not set
# CONFIG_PACKAGE_kmod-iwlwifi is not set
# CONFIG_PACKAGE_kmod-lib80211 is not set
# CONFIG_PACKAGE_kmod-libertas-sdio is not set
# CONFIG_PACKAGE_kmod-libertas-spi is not set
# CONFIG_PACKAGE_kmod-libertas-usb is not set
# CONFIG_PACKAGE_kmod-libipw is not set
CONFIG_PACKAGE_kmod-mac80211=y
# CONFIG_PACKAGE_MAC80211_DEBUGFS is not set
# CONFIG_PACKAGE_MAC80211_TRACING is not set
CONFIG_PACKAGE_MAC80211_MESH=y
# CONFIG_PACKAGE_kmod-mac80211-hwsim is not set
# CONFIG_PACKAGE_kmod-mt76 is not set
CONFIG_PACKAGE_kmod-mt7601u=y
# CONFIG_PACKAGE_kmod-mt7603 is not set
# CONFIG_PACKAGE_kmod-mt7615-firmware is not set
# CONFIG_PACKAGE_kmod-mt7615e is not set
# CONFIG_PACKAGE_kmod-mt7663-firmware-ap is not set
# CONFIG_PACKAGE_kmod-mt7663-firmware-sta is not set
# CONFIG_PACKAGE_kmod-mt7663s is not set
# CONFIG_PACKAGE_kmod-mt7663u is not set
# CONFIG_PACKAGE_kmod-mt76x0e is not set
# CONFIG_PACKAGE_kmod-mt76x0u is not set
# CONFIG_PACKAGE_kmod-mt76x2 is not set
# CONFIG_PACKAGE_kmod-mt76x2u is not set
# CONFIG_PACKAGE_kmod-mt7915e is not set
# CONFIG_PACKAGE_kmod-mt7921e is not set
# CONFIG_PACKAGE_kmod-mwifiex-pcie is not set
# CONFIG_PACKAGE_kmod-mwifiex-sdio is not set
# CONFIG_PACKAGE_kmod-mwl8k is not set
# CONFIG_PACKAGE_kmod-net-prism54 is not set
CONFIG_PACKAGE_kmod-net-rtl8192su=y
# CONFIG_PACKAGE_kmod-owl-loader is not set
CONFIG_PACKAGE_kmod-p54-common=y
# CONFIG_PACKAGE_kmod-p54-pci is not set
CONFIG_PACKAGE_kmod-p54-usb=y
CONFIG_PACKAGE_kmod-rsi91x=y
# CONFIG_PACKAGE_kmod-rsi91x-sdio is not set
CONFIG_PACKAGE_kmod-rsi91x-usb=y
# CONFIG_PACKAGE_kmod-rt2400-pci is not set
# CONFIG_PACKAGE_kmod-rt2500-pci is not set
CONFIG_PACKAGE_kmod-rt2500-usb=y
CONFIG_PACKAGE_kmod-rt2800-lib=y
# CONFIG_PACKAGE_kmod-rt2800-pci is not set
CONFIG_PACKAGE_kmod-rt2800-usb=y
CONFIG_PACKAGE_kmod-rt2x00-lib=y
# CONFIG_PACKAGE_RT2X00_DEBUG is not set
CONFIG_PACKAGE_kmod-rt2x00-usb=y
# CONFIG_PACKAGE_kmod-rt61-pci is not set
CONFIG_PACKAGE_kmod-rt73-usb=y
CONFIG_PACKAGE_kmod-rtl8180=y
CONFIG_PACKAGE_kmod-rtl8187=y
CONFIG_PACKAGE_kmod-rtl8192c-common=y
CONFIG_PACKAGE_kmod-rtl8192ce=y
CONFIG_PACKAGE_kmod-rtl8192cu=y
CONFIG_PACKAGE_kmod-rtl8192de=y
CONFIG_PACKAGE_kmod-rtl8192se=y
CONFIG_PACKAGE_kmod-rtl8723bs=y
CONFIG_PACKAGE_kmod-rtl8812au-ct=y
CONFIG_PACKAGE_kmod-rtl8821ae=y
CONFIG_PACKAGE_kmod-rtl8xxxu=y
CONFIG_PACKAGE_kmod-rtlwifi=y
# CONFIG_PACKAGE_RTLWIFI_DEBUG is not set
CONFIG_PACKAGE_kmod-rtlwifi-btcoexist=y
CONFIG_PACKAGE_kmod-rtlwifi-pci=y
CONFIG_PACKAGE_kmod-rtlwifi-usb=y
CONFIG_PACKAGE_kmod-rtw88=y
# CONFIG_PACKAGE_kmod-wil6210 is not set
# CONFIG_PACKAGE_kmod-wl12xx is not set
# CONFIG_PACKAGE_kmod-wl18xx is not set
# CONFIG_PACKAGE_kmod-wlcore is not set
# CONFIG_PACKAGE_kmod-zd1211rw is not set

# Filesystems:
# CONFIG_PACKAGE_kmod-fs-9p is not set
# CONFIG_PACKAGE_kmod-fs-afs is not set
# CONFIG_PACKAGE_kmod-fs-antfs is not set
CONFIG_PACKAGE_kmod-fs-autofs4=y
CONFIG_PACKAGE_kmod-fs-btrfs=y
CONFIG_PACKAGE_kmod-fs-cifs=y
# CONFIG_PACKAGE_kmod-fs-configfs is not set
# CONFIG_PACKAGE_kmod-fs-cramfs is not set
CONFIG_PACKAGE_kmod-fs-exfat=y
CONFIG_PACKAGE_kmod-fs-exportfs=y
CONFIG_PACKAGE_kmod-fs-ext4=y
CONFIG_PACKAGE_kmod-fs-f2fs=y
CONFIG_PACKAGE_kmod-fs-fscache=m
CONFIG_PACKAGE_kmod-fs-hfs=y
CONFIG_PACKAGE_kmod-fs-hfsplus=y
CONFIG_PACKAGE_kmod-fs-isofs=m
CONFIG_PACKAGE_kmod-fs-jfs=m
# CONFIG_PACKAGE_kmod-fs-ksmbd is not set
# CONFIG_PACKAGE_kmod-fs-minix is not set
CONFIG_PACKAGE_kmod-fs-msdos=y
CONFIG_PACKAGE_kmod-fs-nfs=y
CONFIG_PACKAGE_kmod-fs-nfs-common=y
CONFIG_PACKAGE_kmod-fs-nfs-common-rpcsec=y
CONFIG_PACKAGE_kmod-fs-nfs-v3=y
CONFIG_PACKAGE_kmod-fs-nfs-v4=y
CONFIG_PACKAGE_kmod-fs-nfsd=y
# CONFIG_PACKAGE_kmod-fs-ntfs is not set
CONFIG_PACKAGE_kmod-fs-reiserfs=y
CONFIG_PACKAGE_kmod-fs-squashfs=y
# CONFIG_PACKAGE_kmod-fs-udf is not set
CONFIG_PACKAGE_kmod-fs-vfat=y
CONFIG_PACKAGE_kmod-fs-xfs=y
CONFIG_PACKAGE_kmod-fuse=y

# USB Support:
CONFIG_PACKAGE_kmod-usb-core=y
CONFIG_PACKAGE_kmod-usb-dwc2=y
CONFIG_PACKAGE_kmod-usb-dwc3=y
CONFIG_PACKAGE_kmod-usb-ehci=y
CONFIG_PACKAGE_kmod-usb-ohci=y
CONFIG_PACKAGE_kmod-usb-ohci-pci=y
CONFIG_PACKAGE_kmod-usb-hid=y
CONFIG_PACKAGE_kmod-usb-net=y
CONFIG_PACKAGE_kmod-usb-net-asix=y
CONFIG_PACKAGE_kmod-usb-net-asix-ax88179=y
CONFIG_PACKAGE_kmod-usb-net-cdc-eem=y
CONFIG_PACKAGE_kmod-usb-net-cdc-ether=y
CONFIG_PACKAGE_kmod-usb-net-cdc-mbim=y
CONFIG_PACKAGE_kmod-usb-net-cdc-ncm=y
CONFIG_PACKAGE_kmod-usb-net-cdc-subset=y
CONFIG_PACKAGE_kmod-usb-net-dm9601-ether=y
CONFIG_PACKAGE_kmod-usb-net-hso=y
CONFIG_PACKAGE_kmod-usb-net-huawei-cdc-ncm=y
CONFIG_PACKAGE_kmod-usb-net-ipheth=y
CONFIG_PACKAGE_kmod-usb-net-kalmia=y
CONFIG_PACKAGE_kmod-usb-net-kaweth=y
CONFIG_PACKAGE_kmod-usb-net-mcs7830=y
CONFIG_PACKAGE_kmod-usb-net-pegasus=y
CONFIG_PACKAGE_kmod-usb-net-pl=y
CONFIG_PACKAGE_kmod-usb-net-qmi-wwan=y
CONFIG_PACKAGE_kmod-usb-net-rndis=y
CONFIG_PACKAGE_kmod-usb-net-rtl8150=y
CONFIG_PACKAGE_kmod-usb-net-rtl8152=y
CONFIG_PACKAGE_kmod-usb-net-sierrawireless=y
CONFIG_PACKAGE_kmod-usb-net-smsc95xx=y
CONFIG_PACKAGE_kmod-usb-net-sr9700=y
CONFIG_PACKAGE_kmod-usb-ohci=y
CONFIG_PACKAGE_kmod-usb-printer=y
CONFIG_PACKAGE_kmod-usb-serial=y
CONFIG_PACKAGE_kmod-usb-serial-ch341=y
CONFIG_PACKAGE_kmod-usb-serial-cp210x=y
CONFIG_PACKAGE_kmod-usb-serial-option=y
CONFIG_PACKAGE_kmod-usb-serial-pl2303=y
CONFIG_PACKAGE_kmod-usb-serial-wwan=y
CONFIG_PACKAGE_kmod-usb-storage=y
CONFIG_PACKAGE_kmod-usb-storage-extras=y
CONFIG_PACKAGE_kmod-usb-uhci=y
CONFIG_PACKAGE_kmod-usb-wdm=y
CONFIG_PACKAGE_kmod-usb2=y
CONFIG_PACKAGE_kmod-usb2-pci=y
CONFIG_PACKAGE_kmod-usb3=y
CONFIG_PACKAGE_kmod-usbip=y
CONFIG_PACKAGE_kmod-usbip-client=y
CONFIG_PACKAGE_kmod-usbip-server=y
CONFIG_PACKAGE_kmod-usbmon=y

# WWAN:
# CONFIG_PACKAGE_adb-enablemodem is not set
CONFIG_PACKAGE_comgt=y
# CONFIG_PACKAGE_comgt-directip is not set
CONFIG_PACKAGE_comgt-ncm=y
# CONFIG_PACKAGE_umbim is not set
CONFIG_PACKAGE_uqmi=y

# Network Devices:
# CONFIG_PACKAGE_kmod-3c59x is not set
# CONFIG_PACKAGE_kmod-8139cp is not set
# CONFIG_PACKAGE_kmod-8139too is not set
# CONFIG_PACKAGE_kmod-alx is not set
# CONFIG_PACKAGE_kmod-atl1 is not set
# CONFIG_PACKAGE_kmod-atl1c is not set
# CONFIG_PACKAGE_kmod-atl1e is not set
# CONFIG_PACKAGE_kmod-atl2 is not set
# CONFIG_PACKAGE_kmod-b44 is not set
# CONFIG_PACKAGE_kmod-be2net is not set
# CONFIG_PACKAGE_kmod-bnx2 is not set
# CONFIG_PACKAGE_kmod-bnx2x is not set
# CONFIG_PACKAGE_kmod-dm9000 is not set
CONFIG_PACKAGE_kmod-dummy=y
# CONFIG_PACKAGE_kmod-e100 is not set
# CONFIG_PACKAGE_kmod-e1000 is not set
# CONFIG_PACKAGE_kmod-et131x is not set
# CONFIG_PACKAGE_kmod-ethoc is not set
# CONFIG_PACKAGE_kmod-forcedeth is not set
# CONFIG_PACKAGE_kmod-hfcmulti is not set
# CONFIG_PACKAGE_kmod-hfcpci is not set
# CONFIG_PACKAGE_kmod-i40e is not set
# CONFIG_PACKAGE_kmod-iavf is not set
CONFIG_PACKAGE_kmod-ifb=y
# CONFIG_PACKAGE_kmod-igb is not set
# CONFIG_PACKAGE_kmod-ixgbe is not set
# CONFIG_PACKAGE_kmod-ixgbevf is not set
CONFIG_PACKAGE_kmod-libphy=y
CONFIG_PACKAGE_kmod-macvlan=y
# CONFIG_PACKAGE_kmod-mdio-gpio is not set
CONFIG_PACKAGE_kmod-mii=y
# CONFIG_PACKAGE_kmod-mlx4-core is not set
# CONFIG_PACKAGE_kmod-mlx5-core is not set
# CONFIG_PACKAGE_kmod-natsemi is not set
# CONFIG_PACKAGE_kmod-ne2k-pci is not set
# CONFIG_PACKAGE_kmod-niu is not set
# CONFIG_PACKAGE_kmod-of-mdio is not set
# CONFIG_PACKAGE_kmod-pcnet32 is not set
# CONFIG_PACKAGE_kmod-phy-bcm84881 is not set
# CONFIG_PACKAGE_kmod-phy-broadcom is not set
# CONFIG_PACKAGE_kmod-phy-realtek is not set
# CONFIG_PACKAGE_kmod-phylink is not set
# CONFIG_PACKAGE_kmod-r6040 is not set
# CONFIG_PACKAGE_kmod-r8125 is not set
# CONFIG_PACKAGE_kmod-r8168 is not set
# CONFIG_PACKAGE_kmod-r8169 is not set
# CONFIG_PACKAGE_kmod-sfp is not set
# CONFIG_PACKAGE_kmod-siit is not set
# CONFIG_PACKAGE_kmod-sis190 is not set
# CONFIG_PACKAGE_kmod-sis900 is not set
# CONFIG_PACKAGE_kmod-skge is not set
# CONFIG_PACKAGE_kmod-sky2 is not set
# CONFIG_PACKAGE_kmod-solos-pci is not set
# CONFIG_PACKAGE_kmod-spi-ks8995 is not set
# CONFIG_PACKAGE_kmod-swconfig is not set
# CONFIG_PACKAGE_kmod-switch-bcm53xx is not set
# CONFIG_PACKAGE_kmod-switch-bcm53xx-mdio is not set
# CONFIG_PACKAGE_kmod-switch-ip17xx is not set
# CONFIG_PACKAGE_kmod-switch-mvsw61xx is not set
# CONFIG_PACKAGE_kmod-switch-rtl8306 is not set
# CONFIG_PACKAGE_kmod-switch-rtl8366-smi is not set
# CONFIG_PACKAGE_kmod-switch-rtl8366rb is not set
# CONFIG_PACKAGE_kmod-switch-rtl8366s is not set
# CONFIG_PACKAGE_kmod-switch-rtl8367b is not set
# CONFIG_PACKAGE_kmod-tg3 is not set
# CONFIG_PACKAGE_kmod-tulip is not set
# CONFIG_PACKAGE_kmod-via-rhine is not set
# CONFIG_PACKAGE_kmod-via-velocity is not set
# CONFIG_PACKAGE_kmod-vmxnet3 is not set

# WirelessAPD:
CONFIG_PACKAGE_hostapd=y
CONFIG_PACKAGE_hostapd-common=y
CONFIG_PACKAGE_wpa-cli=y
CONFIG_PACKAGE_wpad-basic=y

# Protocols:
CONFIG_PACKAGE_luci-proto-3g=y
CONFIG_PACKAGE_luci-proto-bonding=y
CONFIG_PACKAGE_luci-proto-ipip=y
CONFIG_PACKAGE_luci-proto-ipv6=y
CONFIG_PACKAGE_luci-proto-ncm=y
CONFIG_PACKAGE_luci-proto-openconnect=y
CONFIG_PACKAGE_luci-proto-ppp=y
CONFIG_PACKAGE_luci-proto-qmi=y
CONFIG_PACKAGE_luci-proto-relay=y
# CONFIG_PACKAGE_luci-proto-vpnc is not set
# CONFIG_PACKAGE_luci-proto-wireguard is not set

# Other Config info:
CONFIG_BRCMFMAC_SDIO=y
CONFIG_BRCMFMAC_USB=y

# LuCI-app:
# CONFIG_PACKAGE_luci-app-acl is not set
CONFIG_PACKAGE_luci-app-acme=y
# CONFIG_PACKAGE_luci-app-adblock is not set
# CONFIG_PACKAGE_luci-app-advanced-reboot is not set
# CONFIG_PACKAGE_luci-app-ahcp is not set
CONFIG_PACKAGE_luci-app-amlogic=y
# CONFIG_PACKAGE_luci-app-aria2 is not set
# CONFIG_PACKAGE_luci-app-attendedsysupgrade is not set
# CONFIG_PACKAGE_luci-app-babeld is not set
# CONFIG_PACKAGE_luci-app-banip is not set
# CONFIG_PACKAGE_luci-app-bcp38 is not set
# CONFIG_PACKAGE_luci-app-bird1-ipv4 is not set
# CONFIG_PACKAGE_luci-app-bird1-ipv6 is not set
# CONFIG_PACKAGE_luci-app-bmx6 is not set
# CONFIG_PACKAGE_luci-app-bmx7 is not set
# CONFIG_PACKAGE_luci-app-cjdns is not set
# CONFIG_PACKAGE_luci-app-clamav is not set
# CONFIG_PACKAGE_luci-app-commands is not set
# CONFIG_PACKAGE_luci-app-cshark is not set
# CONFIG_PACKAGE_luci-app-dawn is not set
# CONFIG_PACKAGE_luci-app-dcwapd is not set
CONFIG_PACKAGE_luci-app-ddns=y
# CONFIG_PACKAGE_luci-app-diag-core is not set
# CONFIG_PACKAGE_luci-app-dnscrypt-proxy is not set
CONFIG_PACKAGE_luci-app-dockerman=y
# CONFIG_PACKAGE_luci-app-dump1090 is not set
# CONFIG_PACKAGE_luci-app-dynapoint is not set
# CONFIG_PACKAGE_luci-app-eoip is not set
CONFIG_PACKAGE_luci-app-firewall=y
CONFIG_PACKAGE_luci-app-frpc=y
CONFIG_PACKAGE_luci-app-frps=y
# CONFIG_PACKAGE_luci-app-fwknopd is not set
# CONFIG_PACKAGE_luci-app-hd-idle is not set
# CONFIG_PACKAGE_luci-app-hnet is not set
# CONFIG_PACKAGE_luci-app-https-dns-proxy is not set
# CONFIG_PACKAGE_luci-app-ksmbd is not set
# CONFIG_PACKAGE_luci-app-ledtrig-rssi is not set
# CONFIG_PACKAGE_luci-app-ledtrig-switch is not set
# CONFIG_PACKAGE_luci-app-ledtrig-usbport is not set
# CONFIG_PACKAGE_luci-app-lxc is not set
# CONFIG_PACKAGE_luci-app-minidlna is not set
# CONFIG_PACKAGE_luci-app-mjpg-streamer is not set
CONFIG_PACKAGE_luci-app-mwan3=y
# CONFIG_PACKAGE_luci-app-nextdns is not set
CONFIG_PACKAGE_luci-app-nft-qos=y
# CONFIG_PACKAGE_luci-app-nlbwmon is not set
# CONFIG_PACKAGE_luci-app-ntpc is not set
# CONFIG_PACKAGE_luci-app-nut is not set
# CONFIG_PACKAGE_luci-app-ocserv is not set
# CONFIG_PACKAGE_luci-app-olsr is not set
# CONFIG_PACKAGE_luci-app-olsr-services is not set
# CONFIG_PACKAGE_luci-app-olsr-viz is not set
# CONFIG_PACKAGE_luci-app-omcproxy is not set
CONFIG_PACKAGE_luci-app-openvpn=y
CONFIG_PACKAGE_luci-app-opkg=y
# CONFIG_PACKAGE_luci-app-p910nd is not set
# CONFIG_PACKAGE_luci-app-pagekitec is not set
# CONFIG_PACKAGE_luci-app-polipo is not set
# CONFIG_PACKAGE_luci-app-privoxy is not set
# CONFIG_PACKAGE_luci-app-qos is not set
# CONFIG_PACKAGE_luci-app-radicale is not set
# CONFIG_PACKAGE_luci-app-radicale2 is not set
# CONFIG_PACKAGE_luci-app-rosy-file-server is not set
# CONFIG_PACKAGE_luci-app-rp-pppoe-server is not set
CONFIG_PACKAGE_luci-app-samba4=y
# CONFIG_PACKAGE_luci-app-ser2net is not set
# CONFIG_PACKAGE_luci-app-shadowsocks-libev is not set
# CONFIG_PACKAGE_luci-app-shairplay is not set
# CONFIG_PACKAGE_luci-app-siitwizard is not set
# CONFIG_PACKAGE_luci-app-simple-adblock is not set
# CONFIG_PACKAGE_luci-app-smartdns is not set
# CONFIG_PACKAGE_luci-app-snmpd is not set
# CONFIG_PACKAGE_luci-app-softether is not set
# CONFIG_PACKAGE_luci-app-splash is not set
# CONFIG_PACKAGE_luci-app-sqm is not set
# CONFIG_PACKAGE_luci-app-squid is not set
# CONFIG_PACKAGE_luci-app-statistics is not set
# CONFIG_PACKAGE_luci-app-tinyproxy is not set
CONFIG_PACKAGE_luci-app-transmission=y
# CONFIG_PACKAGE_luci-app-travelmate is not set
CONFIG_PACKAGE_luci-app-ttyd=y
# CONFIG_PACKAGE_luci-app-udpxy is not set
# CONFIG_PACKAGE_luci-app-uhttpd is not set
# CONFIG_PACKAGE_luci-app-unbound is not set
CONFIG_PACKAGE_luci-app-upnp=y
# CONFIG_PACKAGE_luci-app-vnstat is not set
# CONFIG_PACKAGE_luci-app-vnstat2 is not set
# CONFIG_PACKAGE_luci-app-vpn-policy-routing is not set
# CONFIG_PACKAGE_luci-app-vpnbypass is not set
# CONFIG_PACKAGE_luci-app-watchcat is not set
# CONFIG_PACKAGE_luci-app-wifischedule is not set
# CONFIG_PACKAGE_luci-app-wireguard is not set
CONFIG_PACKAGE_luci-app-wol=y
# CONFIG_PACKAGE_luci-app-xinetd is not set
# CONFIG_PACKAGE_luci-app-yggdrasil is not set

# LuCI-theme:
CONFIG_PACKAGE_luci-theme-material=y
# CONFIG_PACKAGE_luci-theme-bootstrap is not set
# CONFIG_PACKAGE_luci-theme-openwrt is not set
# CONFIG_PACKAGE_luci-theme-openwrt-2020 is not set

# Perl:
CONFIG_PACKAGE_perl=y
CONFIG_PACKAGE_perl-http-date=y
CONFIG_PACKAGE_perlbase-getopt=y
CONFIG_PACKAGE_perlbase-time=y
CONFIG_PACKAGE_perlbase-unicode=y
CONFIG_PACKAGE_perlbase-utf8=y

# Software:
CONFIG_PACKAGE_aircrack-ng=m
CONFIG_PACKAGE_apcupsd=y
CONFIG_PACKAGE_apcupsd-cgi=y
CONFIG_PACKAGE_attr=y
CONFIG_PACKAGE_autocore-arm=y
# CONFIG_PACKAGE_autosamba is not set
CONFIG_PACKAGE_bash=y
CONFIG_PACKAGE_base-files=y
CONFIG_PACKAGE_blkid=y
CONFIG_PACKAGE_blockd=y
CONFIG_PACKAGE_block-mount=y
CONFIG_PACKAGE_bsdtar=y
CONFIG_PACKAGE_btrfs-progs=y
CONFIG_PACKAGE_bzip2=y
CONFIG_PACKAGE_ca-bundle=y
CONFIG_PACKAGE_chattr=y
CONFIG_PACKAGE_curl=y
CONFIG_PACKAGE_cfdisk=y
CONFIG_PACKAGE_coremark=y
CONFIG_PACKAGE_coreutils=y
CONFIG_PACKAGE_coreutils-base64=y
CONFIG_PACKAGE_coreutils-nohup=y
CONFIG_PACKAGE_default-settings=y
CONFIG_PACKAGE_docker-compose=y
CONFIG_PACKAGE_dumpe2fs=y
CONFIG_PACKAGE_dosfstools=y
CONFIG_PACKAGE_ethtool=y
CONFIG_PACKAGE_e2freefrag=y
CONFIG_PACKAGE_e2fsprogs=y
CONFIG_PACKAGE_f2fs-tools=y
CONFIG_PACKAGE_f2fsck=y
CONFIG_PACKAGE_fdisk=y
CONFIG_PACKAGE_file=y
CONFIG_PACKAGE_gzip=y
CONFIG_PACKAGE_gawk=y
CONFIG_PACKAGE_getopt=y
CONFIG_PACKAGE_htop=y
CONFIG_PACKAGE_iconv=y
CONFIG_PACKAGE_iw=y
CONFIG_PACKAGE_iwinfo=y
CONFIG_PACKAGE_jq=y
CONFIG_PACKAGE_jshn=y
CONFIG_PACKAGE_iftop=y
CONFIG_PACKAGE_iperf3=y
CONFIG_PACKAGE_lsattr=y
CONFIG_PACKAGE_libpci=y
CONFIG_PACKAGE_libpcre=y
CONFIG_PACKAGE_libpcre16=y
CONFIG_PACKAGE_libpcre2=y
CONFIG_PACKAGE_libpcre2-16=y
CONFIG_PACKAGE_libpcre2-32=y
CONFIG_PACKAGE_libpng=y
CONFIG_PACKAGE_libpopt=y
CONFIG_PACKAGE_libprotobuf-c=y
CONFIG_PACKAGE_libqmi=y
CONFIG_PACKAGE_libreadline=y
CONFIG_PACKAGE_libseccomp=y
CONFIG_PACKAGE_libsmartcols=y
CONFIG_PACKAGE_libsndfile=y
CONFIG_PACKAGE_libsoc=y
CONFIG_PACKAGE_libsocks=y
CONFIG_PACKAGE_libsodium=y
CONFIG_PACKAGE_less-wide=y
CONFIG_PACKAGE_libjson-script=y
CONFIG_PACKAGE_libnetwork=y
CONFIG_PACKAGE_lrzsz=y
CONFIG_PACKAGE_lsof=y
CONFIG_PACKAGE_lm-sensors=y
CONFIG_PACKAGE_losetup=y
CONFIG_PACKAGE_lsblk=y
CONFIG_PACKAGE_lscpu=y
CONFIG_PACKAGE_lz4=y
CONFIG_PACKAGE_mkf2fs=y
CONFIG_PACKAGE_mount-utils=y
CONFIG_PACKAGE_nano=y
CONFIG_PACKAGE_netdata=y
CONFIG_PACKAGE_ntfs-3g=y
CONFIG_PACKAGE_openssl-util=y
CONFIG_PACKAGE_p7zip=y
CONFIG_PACKAGE_parted=y
CONFIG_PACKAGE_pv=y
CONFIG_PACKAGE_qmi-utils=y
CONFIG_PACKAGE_runc=y
CONFIG_PACKAGE_resize2fs=y
CONFIG_PACKAGE_sysstat=y
CONFIG_PACKAGE_screen=y
CONFIG_PACKAGE_shellsync=y
CONFIG_PACKAGE_smartmontools=y
CONFIG_PACKAGE_smartmontools-drivedb=y
CONFIG_PACKAGE_samba4-admin=y
CONFIG_PACKAGE_samba4-client=y
CONFIG_PACKAGE_samba4-libs=y
CONFIG_PACKAGE_samba4-server=y
CONFIG_SAMBA4_SERVER_NETBIOS=y
CONFIG_SAMBA4_SERVER_AVAHI=y
CONFIG_SAMBA4_SERVER_VFS=y
# CONFIG_SAMBA4_SERVER_VFSX is not set
# CONFIG_SAMBA4_SERVER_AD_DC is not set
CONFIG_PACKAGE_samba4-utils=y
CONFIG_PACKAGE_tree=y
CONFIG_PACKAGE_tune2fs=y
CONFIG_PACKAGE_tar=y
CONFIG_PACKAGE_TAR_POSIX_ACL=y
CONFIG_PACKAGE_TAR_XATTR=y
CONFIG_PACKAGE_TAR_BZIP2=y
CONFIG_PACKAGE_TAR_GZIP=y
CONFIG_PACKAGE_TAR_XZ=y
CONFIG_PACKAGE_TAR_ZSTD=y
CONFIG_PACKAGE_tini=y
CONFIG_PACKAGE_unzip=y
CONFIG_PACKAGE_usb-modeswitch=y
CONFIG_PACKAGE_usbutils=y
CONFIG_PACKAGE_usbreset=y
CONFIG_PACKAGE_uuid=y
CONFIG_PACKAGE_uuidgen=y
CONFIG_PACKAGE_vim=y
CONFIG_PACKAGE_vsftpd-alt=y
CONFIG_PACKAGE_wireless-tools=y
# CONFIG_PACKAGE_wireguard-tools is not set
CONFIG_PACKAGE_whereis=y
CONFIG_PACKAGE_wget=y
CONFIG_PACKAGE_wpad=y
CONFIG_PACKAGE_wwan=y
CONFIG_PACKAGE_xfs-fsck=y
CONFIG_PACKAGE_xfs-mkfs=y
CONFIG_PACKAGE_xz-utils=y
CONFIG_PACKAGE_xz=y
CONFIG_PACKAGE_zstd=y
CONFIG_VSFTPD_USE_UCI_SCRIPTS=y
CONFIG_DOCKER_STO_EXT4=y
CONFIG_DOCKER_STO_BTRFS=y
CONFIG_RUNC_SECCOMP=y
CONFIG_STRACE_NONE=y
CONFIG_PCAP_HAS_USB=y
CONFIG_PCAP_HAS_NETFILTER=y
CONFIG_KERNEL_MAGIC_SYSRQ=y
