### PR TITLE
Update make

### DIFF
--- a/make
+++ b/make
@@ -432,6 +432,9 @@ EOF
     else
         old_fdt_dtb="meson-gxl-s905d-phicomm-n1.dtb"
         sed -i "s/${old_fdt_dtb}/${FDTFILE}/g" uEnv.txt
+        
+        # fix not mount /dev/sda2 for rootfs
+        sed -i "s/LABEL=ROOTFS/UUID=${ROOTFS_UUID}/" uEnv.txt
     fi
 
     # Add u-boot.ext for 5.10 kernel


### PR DESCRIPTION
fix not mount /dev/sda2 for rootfs
because, uuid is uniqe.
`LABEL=ROOTFS` will not work for mounting /dev/sda2