### PR TITLE
Add s905l3a for e900v22c

### DIFF
--- a/.github/workflows/build-openwrt-official-21.02.yml
+++ b/.github/workflows/build-openwrt-official-21.02.yml
@@ -14,7 +14,7 @@ on:
       more_settings:
         description: "More parameter settings"
         required: false
-        default: ""
+        default: "-b s905l3a -k 5.15.25_5.4.180"
   #schedule:
     #- cron: '0 17 * * 0'
 
@@ -124,7 +124,7 @@ jobs:
         body: |
           This is OpenWrt firmware for Amlogic s9xxx tv box
           * Firmware information
-          Default IP: 192.168.1.1
+          Default IP: 192.168.30.6
           Default username: root
           Default password: password
           Default WIFI name: OpenWrt

--- a/.github/workflows/use-releases-file-to-packaging.yml
+++ b/.github/workflows/use-releases-file-to-packaging.yml
@@ -13,11 +13,11 @@ on:
       branch:
         description: 'Select Branch [ official / lede ]'
         required: false
-        default: 'lede'
+        default: 'official'
       more_settings:
         description: "More parameter settings"
         required: false
-        default: ""
+        default: "-b s905l3a -k 5.15.25_5.4.180"
 
 env:
   TZ: Asia/Shanghai
@@ -77,7 +77,7 @@ jobs:
         body: |
           This is OpenWrt firmware for Amlogic s9xxx tv box
           * Firmware information
-          Default IP: 192.168.1.1
+          Default IP: 192.168.30.6
           Default username: root
           Default password: password
           Default WIFI name: OpenWrt

--- a/make
+++ b/make
@@ -284,7 +284,7 @@ confirm_version() {
         UBOOT_OVERLOAD="u-boot-u200.bin"
         MAINLINE_UBOOT="u-boot-u200.bin.sd.bin"
         ANDROID_UBOOT=""
-		AMLOGIC_SOC="s905l3a"
+        AMLOGIC_SOC="s905l3a"
         ;;
     s905x | hg680p | b860h)
         FDTFILE="meson-gxl-s905x-p212.dtb"

--- a/make
+++ b/make
@@ -282,7 +282,7 @@ confirm_version() {
     s905l3a)
         FDTFILE="meson-g12a-u200.dtb"
         UBOOT_OVERLOAD="u-boot-u200.bin"
-        MAINLINE_UBOOT="u-boot-u200.bin.sd.bin"
+        MAINLINE_UBOOT=""
         ANDROID_UBOOT=""
         AMLOGIC_SOC="s905l3a"
         ;;

--- a/make
+++ b/make
@@ -57,7 +57,7 @@ kernel_path="${amlogic_path}/amlogic-kernel"
 uboot_path="${amlogic_path}/amlogic-u-boot"
 configfiles_path="${amlogic_path}/common-files"
 op_release="etc/flippy-openwrt-release" # Add custom openwrt firmware information
-build_openwrt=("a311d" "s922x" "s922x-n2" "s922x-reva" "s905x3" "s905x2" "s905x2-km3" "s912" "s912-t95z" "s905d" "s905d-ki" "s905x" "s905w" "s905")
+build_openwrt=("a311d" "s922x" "s922x-n2" "s922x-reva" "s905x3" "s905x2" "s905x2-km3" "s905l3a" "s912" "s912-t95z" "s905d" "s905d-ki" "s905x" "s905w" "s905")
 #
 # Dependency files repository, Download u-boot and dtb to the local directory
 depends_repo="https://github.com/ophub/amlogic-s9xxx-armbian/tree/main/build-armbian"
@@ -278,6 +278,13 @@ confirm_version() {
         UBOOT_OVERLOAD="u-boot-x96max.bin"
         MAINLINE_UBOOT="x96max-u-boot.bin.sd.bin"
         ANDROID_UBOOT=""
+        ;;
+    s905l3a)
+        FDTFILE="meson-g12a-u200.dtb"
+        UBOOT_OVERLOAD="u-boot-u200.bin"
+        MAINLINE_UBOOT="u-boot-u200.bin.sd.bin"
+        ANDROID_UBOOT=""
+		AMLOGIC_SOC="s905l3a"
         ;;
     s905x | hg680p | b860h)
         FDTFILE="meson-gxl-s905x-p212.dtb"

--- a/router-config/openwrt-21.02/.config
+++ b/router-config/openwrt-21.02/.config
@@ -551,8 +551,8 @@ CONFIG_PACKAGE_luci-app-wol=y
 # CONFIG_PACKAGE_luci-app-yggdrasil is not set
 
 # LuCI-theme:
-CONFIG_PACKAGE_luci-theme-material=y
-# CONFIG_PACKAGE_luci-theme-bootstrap is not set
+# CONFIG_PACKAGE_luci-theme-material=y
+CONFIG_PACKAGE_luci-theme-bootstrap is not set
 # CONFIG_PACKAGE_luci-theme-openwrt is not set
 # CONFIG_PACKAGE_luci-theme-openwrt-2020 is not set
 

--- a/router-config/openwrt-21.02/diy-part2.sh
+++ b/router-config/openwrt-21.02/diy-part2.sh
@@ -19,7 +19,7 @@ sed -i "s|DISTRIB_REVISION='.*'|DISTRIB_REVISION='R$(date +%Y.%m.%d)'|g" package
 echo "DISTRIB_SOURCECODE='openwrt'" >>package/base-files/files/etc/openwrt_release
 
 # Modify default IP（FROM 192.168.1.1 CHANGE TO 192.168.31.4）
-# sed -i 's/192.168.1.1/192.168.31.4/g' package/base-files/files/bin/config_generate
+sed -i 's/192.168.1.1/192.168.30.6/g' package/base-files/files/bin/config_generate
 
 #
 # ------------------------------- Main source ends -------------------------------


### PR DESCRIPTION
same as armlogic, kernel 5.10 only support boot from usb with eth 100M.
kernel 5.4 bootable but no eth

ttl output for kernel 5.4 in tf

```
G12A:BL:0253b8:61aa2d;FEAT:E0F93180:2000;POC:F;RCY:0;EMMC:0;READ:0;0.0;
                                                                       bl2_stage                                                                                                 _init 0x01
bl2_stage_init 0x81
hw id: 0x0000 - pwm id 0x01
bl2_stage_init 0xc1
bl2_stage_init 0x02

L0:00000000
L1:00000701
L2:00008267
L3:04000000
S1:00000000
B2:00002000
B1:e0f93180

TE: 89594

BL2 Built : 14:02:05, Nov 23 2020. g12a g966c864 - gongwei.chen@droid11-sz

Board ID = 4
Set cpu clk to 24M
Set clk81 to 24M
CPU clk: 1200 MHz
Set clk81 to 166.6M
eMMC boot @ 0
sw8 s
board id: 4
Load FIP HDR DDR from eMMC, src: 0x00010200, des: 0xfffd0000, size: 0x00004000,                                                                                                  part: 0
fw parse done
PIEI prepare done
00000000
emmc switch 1 ok
ddr saved addr:00016000
Load ddr parameter from eMMC, src: 0x02c00000, des: 0xfffd0000, size: 0x00001000                                                                                                 , part: 0
00000000
emmc switch 0 ok
fastboot data verify
result: 255
Cfg max: 12, cur: 1. Board id: 255. Force loop cfg
LPDDR4 probe

LPDDR4_PHY_V_0_1_22-Built : 15:59:30, May 25 2020. g12a gb6bfa83 - gongwei.chen@                                                                                                 droid11-sz
ddr clk to 1176MHz

dmc_version 0000
Check phy result
INFO : End of CA training
INFO : End of initialization
INFO : Training has run successfully!
Check phy result
INFO : End of initialization
INFO : End of read enable training
INFO : End of fine write leveling
INFO : End of read dq deskew training
INFO : End of MPR read delay center optimization
INFO : End of Write leveling coarse delay
INFO : End of read delay center optimization
INFO : Training has run successfully!
Check phy result
INFO : End of initialization
INFO : End of MPR read delay center optimization
INFO : End of write delay center optimization
INFO : End of read delay center optimization
INFO : End of max read latency training
INFO : Training has run successfully!
1D training succeed
Check phy result
INFO : End of initialization
INFO : End of 2D read delay Voltage center optimization
INFO : End of 2D read delay Voltage center optimization
INFO : End of 2D write delay Voltage center optimization
INFO : End of 2D write delay Voltage center optimization
INFO : Training has run successfully!

soc_vref_reg_value 0x 00000025 00000025 00000024 00000024 00000024 00000026 0000                                                                                                 0025 00000024 00000024 00000023 00000025 00000024 00000024 00000025 00000023 000                                                                                                 00025 00000023 00000024 00000022 00000024 00000026 00000026 00000025 00000023 00                                                                                                 000026 00000024 00000025 00000024 00000024 00000026 00000024 00000025 dwc_ddrphy                                                                                                 _apb_wr((0<<20)|(2<<16)|(0<<12)|(0xb0):0004
 dram_vref_reg_value 0x 0000005e
2D training succeed
auto size-- 65535DDR cs0 size: 2048MB
DDR cs1 size: 0MB
DMC_DDR_CTRL: 00c0002cDDR size: 2048MB
cs0 DataBus test pass
cs0 AddrBus test pass

non-sec scramble use zero key
ddr scramble enabled

100bdlr_step_size ps== 429
result report
boot times 0Enable ddr reg access
00000000
emmc switch 3 ok
Authentication key not yet programmed
get rpmb counter error 0x00000007
00000000
emmc switch 0 ok
Load FIP HDR from eMMC, src: 0x00010200, des: 0x01700000, size: 0x00004000, part                                                                                                 : 0
Load BL3X from eMMC, src: 0x00078200, des: 0x01768000, size: 0x000d6a00, part: 0
0.0;M3 CHK:0;cm4_sp_mode 0
[Image: g12a_v1.1.3394-7d43064d5 2020-05-07 15:37:06 gongwei.chen@droid11-sz]
OPS=0x70
ring efuse init
28 0b 70 00 01 35 2c 00 00 01 32 38 30 4b 41 50
[0.014271 Inits done]
secure task start!
high task start!
low task start!
boot bl31
NOTICE:  BL31: v1.3(release):9d705ef56-dirty
NOTICE:  BL31: Built : 19:18:02, Jul 28 2021
NOTICE:  BL31: G12A normal boot!
NOTICE:  BL31: BL33 decompress pass
ERROR:   Error initializing runtime service opteed_fast


U-Boot 2015.01 (Sep 26 2021 - 14:35:31)

DRAM:  2 GiB
Relocation Offset is: 76e45000
mmu cfg end: 0x80000000
mmu cfg end: 0x80000000
spi_post_bind(spifc): req_seq = 0
register usb cfg[0][1] = 0000000077f3be68
gpio: pin GPIOAO_9 (gpio 9) value is 0
NAND:  get_sys_clk_rate_mtd() 292, clock setting 200!
bus cycle0: 6,timing: 7
NAND device id: 0 ff ff ff ff ff
No NAND device found!!!
nand init failed: -6
get_sys_clk_rate_mtd() 292, clock setting 200!
bus cycle0: 6,timing: 7
NAND device id: 0 ff ff ff ff ff
No NAND device found!!!
nand init failed: -6
MMC:   aml_priv->desc_buf = 0x0000000073e35d90
aml_priv->desc_buf = 0x0000000073e380d0
SDIO Port B: 0, SDIO Port C: 1
co-phase 0x3, tx-dly 0, clock 400000
co-phase 0x3, tx-dly 0, clock 400000
co-phase 0x3, tx-dly 0, clock 400000
emmc/sd response timeout, cmd8, cmd->cmdarg=0x1aa, status=0x1ff2800
emmc/sd response timeout, cmd55, cmd->cmdarg=0x0, status=0x1ff2800
co-phase 0x3, tx-dly 0, clock 400000
co-phase 0x3, tx-dly 0, clock 40000000
[set_emmc_calc_fixed_adj][875]find fixed adj_delay=20
init_part() 297: PART_TYPE_AML
[mmc_init] mmc init success
      Amlogic multi-dtb tool
      GZIP format, decompress...
      Multi dtb detected
      Multi dtb tool version: v2 .
      Support 3 dtbs.
        aml_dt soc: g12a platform: u212 variant: 2g
        dtb 0 soc: g12a   plat: u212   vari: 1g
        dtb 1 soc: g12a   plat: u212   vari: 2g
        dtb 2 soc: sm1   plat: ac213   vari: 2g
      Find match dtb: 1
start dts,buffer=0000000073e3a920,dt_addr=0000000073e3a920
get_partition_from_dts() 92: ret 0
      Amlogic multi-dtb tool
      Single dtb detected
parts: 21
00:      logo   0000000000800000 1
01:  recovery   0000000001800000 1
02:      misc   0000000000800000 1
03:      dtbo   0000000000800000 1
04:  cri_data   0000000000800000 2
05:     param   0000000001000000 2
06:      boot   0000000001000000 1
set has_boot_slot = 0
07:       rsv   0000000001000000 1
08:  metadata   0000000001000000 1
09:    vbmeta   0000000000200000 1
10:       tee   0000000002000000 1
11:    vendor   0000000014000000 1
12:     skmac   0000000000400000 1
13:       odm   0000000001000000 1
14:    system   0000000050000000 1
15:   product   0000000008000000 1
16:       ctc   0000000010000000 1
17:   skparam   0000000001000000 2
18:  skbackup   0000000030000000 2
19:     cache   0000000040000000 2
20:      data   ffffffffffffffff 4
init_part() 297: PART_TYPE_AML
eMMC/TSD partition table have been checked OK!
crc32_s:0x1577dad == storage crc_pattern:0x1577dad!!!
crc32_s:0xee152b83 == storage crc_pattern:0xee152b83!!!
crc32_s:0x79f50f07 == storage crc_pattern:0x79f50f07!!!
mmc env offset: 0x6c00000
In:    serial
Out:   serial
Err:   serial
reboot_mode=cold_boot
[store]To run cmd[emmc dtb_read 0x1000000 0x40000]
_verify_dtb_checksum()-3476: calc 43030b8b, store 43030b8b
_verify_dtb_checksum()-3476: calc 43030b8b, store 43030b8b
dtb_read()-3691: total valid 2
update_old_dtb()-3672: do nothing
      Amlogic multi-dtb tool
      GZIP format, decompress...
      Multi dtb detected
      Multi dtb tool version: v2 .
      Support 3 dtbs.
        aml_dt soc: g12a platform: u212 variant: 2g
        dtb 0 soc: g12a   plat: u212   vari: 1g
        dtb 1 soc: g12a   plat: u212   vari: 2g
        dtb 2 soc: sm1   plat: ac213   vari: 2g
      Find match dtb: 1
amlkey_init() enter!
[EFUSE_MSG]keynum is 4
vpu: driver version: v20190313
vpu: detect chip type: 8
vpu: clk_level default: 7(666667000Hz), max: 7(666667000Hz)
vpu: clk_level in dts: 7
vpu: vpu_power_on
vpu: set_vpu_clk
vpu: set clk: 666667000Hz, readback: 666666667Hz(0x100)
vpu: set_vpu_clk finish
vpu: vpu_module_init_config
vpp: vpp_init
vpp: vpp osd2 matrix rgb2yuv..............
hdr_func 4, hdr_process_select 0x1
cvbs: cpuid:0x28
vdac_gsw_init: 0x0
cvbs: find clk_path: 0x0
cvbs: find performance_pal config
cvbs: find performance_ntsc config
aml_config_dtb 637
aml_config_dtb 667
co_phase = <0x00000003>
caps2 = "MMC_CAP2_HS200"
f_max = <0x02faf080>
status = "disabled"
status = "okay"
wipe_data=successful
wipe_cache=successful
upgrade_step=2
reboot_mode:::: cold_boot
ext4logoLoadCmd=ext4load mmc 1:${logoPart} ${logoLoadAddr} ${ext4LogoPath}
** File not found /logo_files/bootup.bmp **
Err imgread(L815):Fail in load logo cmd
logo part bootup
[OSD]load fb addr from dts:/meson-fb
[OSD]set initrd_high: 0x7f800000
[OSD]fb_addr for logo: 0x7f800000
[OSD]load fb addr from dts:/meson-fb
[OSD]fb_addr for logo: 0x7f800000
[OSD]VPP_OFIFO_SIZE:0xfff01fff
[CANVAS]canvas init
[CANVAS]addr=0x7f800000 width=5760, height=2160
[OSD]osd_hw.free_dst_data: 0,1919,0,1079
[OSD]osd1_update_disp_freescale_enable
cvbs: outputmode[1080p60hz] is invalid
vpp: vpp_matrix_update: 2
set hdmitx VIC = 16
aml_audio_init
config HPLL = 5940000 frac_rate = 0
HPLL: 0x3b3a04f7
HPLL: 0x1b3a04f7
HPLLv1: 0xdb3a04f7
config HPLL done
j = 6  vid_clk_div = 1
hdmitx: set enc for VIC: 16
hdmitx phy setting done
rx version is 1.4 or below  div=10
hdmtix: set audio
hdmi_tx_set: save mode: 1080p60hz, attr: 444,8bit, hdmichecksum: <NULL>
Saving Environment to aml-storage...
mmc env offset: 0x6c00000
Writing to MMC(1)... done
hdr_packet
vpp: hdr_policy = 2
vpp: Rx hdr_info.hdr_sup_eotf_smpte_st_2084 = 0
time_out = 493e0
key[0] = 66994cb3
key[1] = 6699fd01
key[2] = 6699dd22
irkey - irkey <timeout> <key1> ...<keyN> - maximum value of N: 10

Usage:
irkey - No additional help available.
time_out = 0
key[0] = 3ec14cb3
key[1] = 3ec1fd01
key[2] = 3ec1dd22
irkey - irkey <timeout> <key1> ...<keyN> - maximum value of N: 10

Usage:
irkey - No additional help available.
Command: bcb uboot-command
Start read misc partition datas!
BCB hasn't any datas,exit!
InUsbBurn
wait for phy ready count is 0
noSof
sof timeout, reset usb phy tuning
rebootmode=cold_boot
Saving Environment to aml-storage...
mmc env offset: 0x6c00000
Writing to MMC(1)... done
Hit Enter or space or Ctrl+C key to stop autoboot -- :  0
card in
co-phase 0x2, tx-dly 0, clock 400000
co-phase 0x2, tx-dly 0, clock 400000
co-phase 0x2, tx-dly 0, clock 400000
co-phase 0x2, tx-dly 0, clock 400000
co-phase 0x2, tx-dly 0, clock 40000000
init_part() 282: PART_TYPE_DOS
[mmc_init] mmc init success
Device: SDIO Port B
Manufacturer ID: 89
OEM: 303
Name: NCard
Tran Speed: 50000000
Rd Block Len: 512
SD version 3.0
High Capacity: Yes
Capacity: (0xe8f600000 Bytes) 58.2 GiB
mmc clock: 40000000
Bus Width: 4-bit
reading s905_autoscript
1654 bytes read in 8 ms (201.2 KiB/s)
## Executing script at 01020000
start amlogic old u-boot
## Error: "bootfromsd" not defined
reading boot_android
** Unable to read file boot_android **
** Bad device usb 0 **
reading u-boot.ext
** Unable to read file u-boot.ext **
** Bad device usb 0 **
reading uEnv.txt
309 bytes read in 12 ms (24.4 KiB/s)
mac=A0:4C:0C:04:13:81
reading /zImage
20685312 bytes read in 1285 ms (15.4 MiB/s)
reading /uInitrd
6188924 bytes read in 399 ms (14.8 MiB/s)
reading /dtb/amlogic/meson-g12a-u200.dtb
45932 bytes read in 16 ms (2.7 MiB/s)
## Error: "aadmac" not defined
libfdt fdt_path_offset() returned FDT_ERR_NOTFOUND
[rsvmem] fdt get prop fail.
## Loading init Ramdisk from Legacy Image at 13000000 ...
   Image Name:   uInitrd
   Image Type:   AArch64 Linux RAMDisk Image (gzip compressed)
   Data Size:    6188860 Bytes = 5.9 MiB
   Load Address: 00000000
   Entry Point:  00000000
   Verifying Checksum ... OK
[store]Is good fdt check header, no need decrypt!
active_slot is normal
load dtb from 0x1000000 ......
      Amlogic multi-dtb tool
      Single dtb detected
## Flattened Device Tree blob at 01000000
   Booting using the fdt blob at 0x1000000
find 1 dtbos
No androidboot.dtbo_idx configured
And no dtbos will be applied
libfdt fdt_path_offset() returned FDT_ERR_NOTFOUND
[rsvmem] fdt get prop fail.
   Loading Ramdisk to 7384b000, end 73e31f3c ... OK
   Loading Device Tree to 000000001fff1000, end 000000001ffff421 ... OK
fdt_fixup_memory_banks, reg:000000001fffb2dc
DTS already have 'reg' property

Starting kernel ...

uboot time: 5101765 us
[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 5.4.182-flippy-70+o (root@univm25) (gcc version 11.                                                                                                 2.0 (Ubuntu 11.2.0-17ubuntu1)) #388 SMP PREEMPT Wed Mar 2 20:13:57 CST 2022
[    0.000000] Machine model: Amlogic Meson G12A U200 Development Board
[    0.000000] efi: Getting EFI parameters from FDT:
[    0.000000] efi: UEFI not found.
[    0.000000] Reserved memory: created CMA memory pool at 0x0000000030000000, s                                                                                                 ize 256 MiB
[    0.000000] OF: reserved mem: initialized node linux,cma, compatible id share                                                                                                 d-dma-pool
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.0 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.1
[    0.000000] percpu: Embedded 21 pages/cpu s47576 r8192 d30248 u86016
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: ARM erratum 845719
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 250211
[    0.000000] Kernel command line: root=UUID=a2dd3c1e-e33b-48de-ace6-eefd647257                                                                                                 7f console=ttyAML0,115200n8 console=tty0 no_console_suspend consoleblank=0 fsck.                                                                                                 fix=yes fsck.repair=yes net.ifnames=0 cgroup_enable=cpuset cgroup_memory=1 cgrou                                                                                                 p_enable=memory swapaccount=1 mac=A0:4C:0C:04:13:81
[    0.000000] Dentry cache hash table entries: 131072 (order: 8, 1048576 bytes,                                                                                                  linear)
[    0.000000] Inode-cache hash table entries: 65536 (order: 7, 524288 bytes, li                                                                                                 near)
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 690496K/1016732K available (12476K kernel code, 1448K rwd                                                                                                 ata, 5200K rodata, 896K init, 853K bss, 64092K reserved, 262144K cma-reserved)
[    0.000000] random: get_random_u64 called from __kmem_cache_create+0x38/0x590                                                                                                  with crng_init=0
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] rcu: Preemptible hierarchical RCU implementation.
[    0.000000] rcu:     RCU restricting CPUs from NR_CPUS=8 to nr_cpu_ids=4.
[    0.000000]  Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 30 jif                                                                                                 fies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=4
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GIC: Using split EOI/Deactivate mode
[    0.000000] irq_meson_gpio: 100 to 8 gpio interrupt mux initialized
[    0.000000] arch_timer: cp15 timer(s) running at 24.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles:                                                                                                  0x588fe9dc0, max_idle_ns: 440795202592 ns
[    0.000003] sched_clock: 56 bits at 24MHz, resolution 41ns, wraps every 43980                                                                                                 46511097ns
[    0.000129] Console: colour dummy device 80x25
[    0.000419] printk: console [tty0] enabled
[    0.000454] Calibrating delay loop (skipped), value calculated using timer fr                                                                                                 equency.. 48.00 BogoMIPS (lpj=80000)
[    0.000473] pid_max: default: 32768 minimum: 301
[    0.000581] LSM: Security Framework initializing
[    0.000628] SELinux:  Initializing.
[    0.000700] *** VALIDATE SELinux ***
[    0.000754] Mount-cache hash table entries: 2048 (order: 2, 16384 bytes, line                                                                                                 ar)
[    0.000774] Mountpoint-cache hash table entries: 2048 (order: 2, 16384 bytes,                                                                                                  linear)
[    0.000832] *** VALIDATE tmpfs ***
[    0.001240] *** VALIDATE proc ***
[    0.001446] *** VALIDATE cgroup1 ***
[    0.001459] *** VALIDATE cgroup2 ***
[    0.002117] ASID allocator initialised with 32768 entries
[    0.002204] rcu: Hierarchical SRCU implementation.
[    0.004432] EFI services will not be available.
[    0.004711] smp: Bringing up secondary CPUs ...
[    0.005216] Detected VIPT I-cache on CPU1
[    0.005261] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.005794] Detected VIPT I-cache on CPU2
[    0.005818] CPU2: Booted secondary processor 0x0000000002 [0x410fd034]
[    0.006296] Detected VIPT I-cache on CPU3
[    0.006318] CPU3: Booted secondary processor 0x0000000003 [0x410fd034]
[    0.006385] smp: Brought up 1 node, 4 CPUs
[    0.006441] SMP: Total of 4 processors activated.
[    0.006452] CPU features: detected: 32-bit EL0 Support
[    0.006464] CPU features: detected: CRC32 instructions
[    0.007010] CPU: All CPU(s) started at EL2
[    0.007035] alternatives: patching kernel code
[    0.007815] devtmpfs: initialized
[    0.015966] Registered cp15_barrier emulation handler
[    0.015997] Registered setend emulation handler
[    0.016183] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, ma                                                                                                 x_idle_ns: 6370867519511994 ns
[    0.016209] futex hash table entries: 1024 (order: 4, 65536 bytes, linear)
[    0.022290] xor: measuring software checksum speed
[    0.053415]    8regs     :  2301.600 MB/sec
[    0.086787]    32regs    :  2722.800 MB/sec
[    0.120160]    arm64_neon:  2104.800 MB/sec
[    0.120170] xor: using function: 32regs (2722.800 MB/sec)
[    0.120226] pinctrl core: initialized pinctrl subsystem
[    0.120730] DMI not present or invalid.
[    0.121028] NET: Registered protocol family 16
[    0.122593] DMA: preallocated 256 KiB pool for atomic allocations
[    0.122618] audit: initializing netlink subsys (disabled)
[    0.122791] audit: type=2000 audit(0.119:1): state=initialized audit_enabled=                                                                                                 0 res=1
[    0.124102] cpuidle: using governor ladder
[    0.124268] hw-breakpoint: found 6 breakpoint and 4 watchpoint registers.
[    0.124416] Serial: AMBA PL011 UART driver
[    0.140861] HugeTLB registered 1.00 GiB page size, pre-allocated 0 pages
[    0.140887] HugeTLB registered 32.0 MiB page size, pre-allocated 0 pages
[    0.140900] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
[    0.140913] HugeTLB registered 64.0 KiB page size, pre-allocated 0 pages
[    0.142721] cryptd: max_cpu_qlen set to 1000
[    0.200356] raid6: neonx8   gen()  1536 MB/s
[    0.257084] raid6: neonx8   xor()  1438 MB/s
[    0.313850] raid6: neonx4   gen()  1475 MB/s
[    0.370582] raid6: neonx4   xor()  1382 MB/s
[    0.427330] raid6: neonx2   gen()  1129 MB/s
[    0.484077] raid6: neonx2   xor()  1136 MB/s
[    0.540840] raid6: neonx1   gen()   754 MB/s
[    0.597609] raid6: neonx1   xor()   858 MB/s
[    0.654367] raid6: int64x8  gen()  1142 MB/s
[    0.711086] raid6: int64x8  xor()   776 MB/s
[    0.767871] raid6: int64x4  gen()   978 MB/s
[    0.824594] raid6: int64x4  xor()   742 MB/s
[    0.881375] raid6: int64x2  gen()   679 MB/s
[    0.938086] raid6: int64x2  xor()   601 MB/s
[    0.994895] raid6: int64x1  gen()   442 MB/s
[    1.051619] raid6: int64x1  xor()   428 MB/s
[    1.051630] raid6: using algorithm neonx8 gen() 1536 MB/s
[    1.051640] raid6: .... xor() 1438 MB/s, rmw enabled
[    1.051650] raid6: using neon recovery algorithm
[    1.051803] fbcon: Taking over console
[    1.052329] reg-fixed-voltage regulator-flash_1v8: Failed to register regulat                                                                                                 or: -517
[    1.052718] reg-fixed-voltage regulator-vcc_1v8: Failed to register regulator                                                                                                 : -517
[    1.052818] reg-fixed-voltage regulator-vcc_3v3: Failed to register regulator                                                                                                 : -517
[    1.052991] reg-fixed-voltage regulator-vddao_1v8: Failed to register regulat                                                                                                 or: -517
[    1.053088] VDDAO_3V3: supplied by 12V
[    1.053440] iommu: Default domain type: Translated
[    1.053707] vgaarb: loaded
[    1.054117] SCSI subsystem initialized
[    1.054301] usbcore: registered new interface driver usbfs
[    1.054346] usbcore: registered new interface driver hub
[    1.054385] usbcore: registered new device driver usb
[    1.054699] mc: Linux media interface: v0.10
[    1.054729] videodev: Linux video capture interface: v2.00
[    1.054812] pps_core: LinuxPPS API ver. 1 registered
[    1.054823] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giome                                                                                                 tti <giometti@linux.it>
[    1.054847] PTP clock support registered
[    1.055041] EDAC MC: Ver: 3.0.0
[    1.055575] Advanced Linux Sound Architecture Driver Initialized.
[    1.056483] clocksource: Switched to clocksource arch_sys_counter
[    1.056504] *** VALIDATE bpf ***
[    1.056710] VFS: Disk quotas dquot_6.6.0
[    1.056781] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
[    1.056891] FS-Cache: Loaded
[    1.056902] *** VALIDATE ramfs ***
[    1.056931] *** VALIDATE hugetlbfs ***
[    1.062564] thermal_sys: Registered thermal governor 'step_wise'
[    1.063026] NET: Registered protocol family 2
[    1.063178] IP idents hash table entries: 16384 (order: 5, 131072 bytes, line                                                                                                 ar)
[    1.063836] tcp_listen_portaddr_hash hash table entries: 512 (order: 1, 8192                                                                                                  bytes, linear)
[    1.063867] TCP established hash table entries: 8192 (order: 4, 65536 bytes,                                                                                                  linear)
[    1.063936] TCP bind hash table entries: 8192 (order: 5, 131072 bytes, linear                                                                                                 )
[    1.064057] TCP: Hash tables configured (established 8192 bind 8192)
[    1.064164] UDP hash table entries: 512 (order: 2, 16384 bytes, linear)
[    1.064199] UDP-Lite hash table entries: 512 (order: 2, 16384 bytes, linear)
[    1.064357] NET: Registered protocol family 1
[    1.064390] NET: Registered protocol family 44
[    1.064406] PCI: CLS 0 bytes, default 64
[    1.064624] Trying to unpack rootfs image as initramfs...
[    2.920211] Freeing initrd memory: 6040K
[    2.920820] kvm [1]: IPA Size Limit: 40 bits
[    2.921395] kvm [1]: vgic interrupt IRQ1
[    2.921506] kvm [1]: Hyp mode initialized successfully
[    2.926193] Initialise system trusted keyrings
[    2.926324] workingset: timestamp_bits=46 max_order=18 bucket_order=0
[    2.931356] zbud: loaded
[    2.932774] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    2.933078] fuse: init (API version 7.31)
[    2.933176] *** VALIDATE fuse ***
[    2.933191] *** VALIDATE fuse ***
[    2.933504] SGI XFS with ACLs, security attributes, no debug enabled
[    2.947996] Key type asymmetric registered
[    2.948020] Asymmetric key parser 'x509' registered
[    2.948065] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 2                                                                                                 43)
[    2.948154] io scheduler mq-deadline registered
[    2.948166] io scheduler kyber registered
[    2.948312] io scheduler bfq registered
[    2.965864] soc soc0: Amlogic Meson G12A (Unknown) Revision 28:b (70:2) Detec                                                                                                 ted
[    2.967078] VDDCPU: supplied by 12V
[    2.968283] Serial: 8250/16550 driver, 5 ports, IRQ sharing enabled
[    2.969778] Serial: AMBA driver
[    2.970135] ff803000.serial: ttyAML0 at MMIO 0xff803000 (irq = 14, base_baud                                                                                                  = 1500000) is a meson_uart
[    3.880566] printk: console [ttyAML0] enabled
[    3.892031] brd: module loaded
[    4.053178] loop: module loaded
[    4.059335] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
[    4.060258] ehci-pci: EHCI PCI platform driver
[    4.064684] ehci-platform: EHCI generic platform driver
[    4.069967] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
[    4.075943] ohci-pci: OHCI PCI platform driver
[    4.080358] ohci-platform: OHCI generic platform driver
[    4.085946] usbcore: registered new interface driver cdc_wdm
[    4.091148] usbcore: registered new interface driver usb-storage
[    4.097374] mousedev: PS/2 mouse device common for all mice
[    4.103638] meson-vrtc ff8000a8.rtc: registered as rtc0
[    4.108134] i2c /dev entries driver
[    4.121639] Synopsys Designware Multimedia Card Interface Driver
[    4.122709] meson-gx-mmc ffe05000.sd: Got CD GPIO
[    4.154059] meson-sm: secure-monitor enabled
[    4.154538] hidraw: raw HID events driver (C) Jiri Kosina
[    4.158222] usbcore: registered new interface driver usbhid
[    4.163585] usbhid: USB HID core driver
[    4.167405] exFAT: Version 1.3.0
[    4.173624] Initializing XFRM netlink socket
[    4.175201] NET: Registered protocol family 10
[    4.207006] Segment Routing with IPv6
[    4.207188] sit: IPv6, IPv4 and MPLS over IPv4 tunneling driver
[    4.214226] mmc1: new high speed SDXC card at address b368
[    4.214516] bpfilter: Loaded bpfilter_umh pid 196
[    4.217100] mmcblk1: mmc1:b368 NCard 58.2 GiB
[    4.221086] NET: Registered protocol family 17
[    4.227224]  mmcblk1: p1 p2
[    4.229862] NET: Registered protocol family 15
[    4.237034] 8021q: 802.1Q VLAN Support v1.8
[    4.241155] Key type dns_resolver registered
[    4.246149] Loading compiled-in X.509 certificates
[    4.250168] zswap: loaded using pool lzo/zbud
[    4.254580] Key type ._fscrypt registered
[    4.258358] Key type .fscrypt registered
[    4.262822] Btrfs loaded, crc32c=crc32c-generic
[    4.283260] reg-fixed-voltage regulator-flash_1v8: Failed to register regulat                                                                                                 or: -517
[    4.286340] reg-fixed-voltage regulator-vcc_1v8: Failed to register regulator                                                                                                 : -517
[    4.295819] VCC_3V3: supplied by VDDAO_3V3
[    4.299189] VCC_5V: supplied by 12V
[    4.300664] VDDAO_1V8: supplied by VDDAO_3V3
[    4.304900] USB_PWR_EN: supplied by VCC_5V
[    4.386152] meson-drm ff900000.vpu: Queued 3 outputs on vpu
[    4.386407] [drm] Supports vblank timestamp caching Rev 2 (21.10.2013).
[    4.394902] [drm] No driver support for vblank timestamp query.
[    4.423182] meson-dw-hdmi ff600000.hdmi-tx: Detected HDMI TX controller v2.01                                                                                                 a with HDCP (meson_dw_hdmi_phy)
[    4.427675] meson-dw-hdmi ff600000.hdmi-tx: registered DesignWare HDMI I2C bu                                                                                                 s driver
[    4.437847] meson-drm ff900000.vpu: bound ff600000.hdmi-tx (ops meson_dw_hdmi                                                                                                 _ops)
[    4.442999] [drm] Initialized meson 1.0.0 20161109 for ff900000.vpu on minor                                                                                                  0
[    4.555369] random: fast init done
[    4.713763] [drm] kms: can't enable cloning when we probably wanted to.
[    5.002387] Console: switching to colour frame buffer device 240x67
[    5.134623] meson-drm ff900000.vpu: fb0: mesondrmfb frame buffer device
[    5.144739] meson8b-dwmac ff3f0000.ethernet: IRQ eth_wake_irq not found
[    5.148646] meson8b-dwmac ff3f0000.ethernet: IRQ eth_lpi not found
[    5.153994] meson8b-dwmac ff3f0000.ethernet: PTP uses main clock
[    5.159844] meson8b-dwmac ff3f0000.ethernet: no reset control found
[    5.167618] meson8b-dwmac ff3f0000.ethernet: User ID: 0x11, Synopsys ID: 0x37
[    5.173146] meson8b-dwmac ff3f0000.ethernet:         DWMAC1000
[    5.178264] meson8b-dwmac ff3f0000.ethernet: DMA HW capability register suppo                                                                                                 rted
[    5.185684] meson8b-dwmac ff3f0000.ethernet: RX Checksum Offload Engine suppo                                                                                                 rted
[    5.193096] meson8b-dwmac ff3f0000.ethernet: COE Type 2
[    5.198271] meson8b-dwmac ff3f0000.ethernet: TX Checksum insertion supported
[    5.205260] meson8b-dwmac ff3f0000.ethernet: Wake-Up On Lan supported
[    5.211641] meson8b-dwmac ff3f0000.ethernet: Normal descriptors
[    5.217505] meson8b-dwmac ff3f0000.ethernet: Ring mode enabled
[    5.224108] meson8b-dwmac ff3f0000.ethernet: Enable RX Mitigation via HW Watc                                                                                                 hdog Timer
[    5.231221] meson8b-dwmac ff3f0000.ethernet: device MAC address 4e:b5:fc:0e:2                                                                                                 b:81
[    5.240715] dwc3-meson-g12a ffe09000.usb: USB2 ports: 2
[    5.243817] dwc3-meson-g12a ffe09000.usb: USB3 ports: 1
[    5.252982] dwc2 ff400000.usb: ff400000.usb supply vusb_d not found, using du                                                                                                 mmy regulator
[    5.257244] dwc2 ff400000.usb: ff400000.usb supply vusb_a not found, using du                                                                                                 mmy regulator
[    5.266335] dwc2 ff400000.usb: EPs: 7, dedicated fifos, 712 entries in SPRAM
[    5.273423] dwc3 ff500000.usb: Failed to get clk 'ref': -2
[    5.278133] xhci-hcd xhci-hcd.3.auto: xHCI Host Controller
[    5.284194] xhci-hcd xhci-hcd.3.auto: new USB bus registered, assigned bus nu                                                                                                 mber 1
[    5.290961] xhci-hcd xhci-hcd.3.auto: hcc params 0x0228fe6c hci version 0x110                                                                                                  quirks 0x0000000000010010
[    5.300937] xhci-hcd xhci-hcd.3.auto: irq 29, io mem 0xff500000
[    5.306285] usb usb1: New USB device found, idVendor=1d6b, idProduct=0002, bc                                                                                                 dDevice= 5.04
[    5.314943] usb usb1: New USB device strings: Mfr=3, Product=2, SerialNumber=                                                                                                 1
[    5.321353] usb usb1: Product: xHCI Host Controller
[    5.326927] usb usb1: Manufacturer: Linux 5.4.182-flippy-70+o xhci-hcd
[    5.332648] usb usb1: SerialNumber: xhci-hcd.3.auto
[    5.337766] hub 1-0:1.0: USB hub found
[    5.341202] hub 1-0:1.0: 2 ports detected
[    5.345352] xhci-hcd xhci-hcd.3.auto: xHCI Host Controller
[    5.350680] xhci-hcd xhci-hcd.3.auto: new USB bus registered, assigned bus nu                                                                                                 mber 2
[    5.358187] xhci-hcd xhci-hcd.3.auto: Host supports USB 3.0 SuperSpeed
[    5.364692] usb usb2: We don't know the algorithms for LPM for this host, dis                                                                                                 abling LPM.
[    5.372734] usb usb2: New USB device found, idVendor=1d6b, idProduct=0003, bc                                                                                                 dDevice= 5.04
[    5.380860] usb usb2: New USB device strings: Mfr=3, Product=2, SerialNumber=                                                                                                 1
[    5.388020] usb usb2: Product: xHCI Host Controller
[    5.392847] usb usb2: Manufacturer: Linux 5.4.182-flippy-70+o xhci-hcd
[    5.399315] usb usb2: SerialNumber: xhci-hcd.3.auto
[    5.404392] hub 2-0:1.0: USB hub found
[    5.407951] hub 2-0:1.0: 1 port detected
[    5.413200] FLASH_1V8: supplied by VCC_3V3
[    5.416959] VCC_1V8: supplied by VCC_3V3
[    5.427969] meson-gx-mmc ffe07000.mmc: allocated mmc-pwrseq
[    5.456346] meson-vrtc ff8000a8.rtc: setting system clock to 1970-01-01T00:00                                                                                                 :05 UTC (5)
[    5.463214] ALSA device list:
[    5.467133]   No soundcards found.
[    5.473240] Freeing unused kernel memory: 896K
[    5.478480] Run /init as init process
[    5.545988] mmc2: new HS200 MMC card at address 0001
[    5.550564] mmcblk2: mmc2:0001 SPeMMC 7.22 GiB
[    5.555580] mmcblk2boot0: mmc2:0001 SPeMMC partition 1 4.00 MiB
[    5.559842] mmcblk2boot1: mmc2:0001 SPeMMC partition 2 4.00 MiB
[    5.565620] mmcblk2rpmb: mmc2:0001 SPeMMC partition 3 4.00 MiB, chardev (239:                                                                                                 0)
[    5.629858] usb 1-1: new full-speed USB device number 2 using xhci-hcd
[    5.777354] usb 1-1: New USB device found, idVendor=413c, idProduct=301c, bcd                                                                                                 Device= 2.28
[    5.783490] usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=0
[    5.790593] usb 1-1: Product: Dell Universal Receiver
[    5.795382] usb 1-1: Manufacturer: Dell Computer Corp
[    5.819778] input: Dell Computer Corp Dell Universal Receiver as /devices/pla                                                                                                 tform/soc/ffe09000.usb/ff500000.usb/xhci-hcd.3.auto/usb1/1-1/1-1:1.0/0003:413C:3                                                                                                 01C.0001/input/input0
[    5.890728] hid-generic 0003:413C:301C.0001: input,hidraw0: USB HID v1.11 Key                                                                                                 board [Dell Computer Corp Dell Universal Receiver] on usb-xhci-hcd.3.auto-1/inpu                                                                                                 t0
[    5.913766] input: Dell Computer Corp Dell Universal Receiver Mouse as /devic                                                                                                 es/platform/soc/ffe09000.usb/ff500000.usb/xhci-hcd.3.auto/usb1/1-1/1-1:1.1/0003:                                                                                                 413C:301C.0002/input/input1
[    5.929011] input: Dell Computer Corp Dell Universal Receiver Consumer Contro                                                                                                 l as /devices/platform/soc/ffe09000.usb/ff500000.usb/xhci-hcd.3.auto/usb1/1-1/1-                                                                                                 1:1.1/0003:413C:301C.0002/input/input2
[    6.003327] input: Dell Computer Corp Dell Universal Receiver System Control                                                                                                  as /devices/platform/soc/ffe09000.usb/ff500000.usb/xhci-hcd.3.auto/usb1/1-1/1-1:                                                                                                 1.1/0003:413C:301C.0002/input/input3
[    6.019821] hid-generic 0003:413C:301C.0002: input,hidraw1: USB HID v1.11 Mou                                                                                                 se [Dell Computer Corp Dell Universal Receiver] on usb-xhci-hcd.3.auto-1/input1
[    6.038157] hid-generic 0003:413C:301C.0003: hiddev96,hidraw2: USB HID v1.11                                                                                                  Device [Dell Computer Corp Dell Universal Receiver] on usb-xhci-hcd.3.auto-1/inp                                                                                                 ut2
[    6.556888] BTRFS: device label ROOTFS devid 1 transid 21 /dev/mmcblk1p2
[    6.649410] BTRFS info (device mmcblk1p2): flagging fs with big metadata feat                                                                                                 ure
[    6.657665] BTRFS info (device mmcblk1p2): disk space caching is enabled
[    6.665130] BTRFS info (device mmcblk1p2): has skinny extents
[    6.696904] BTRFS info (device mmcblk1p2): enabling ssd optimizations
[    6.880468] init: Console is alive
[   14.738792] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[   14.801117] [drm] kms: can't enable cloning when we probably wanted to.
[   14.826057] ehci-fsl: Freescale EHCI Host controller driver
[   14.854034] uhci_hcd: USB Universal Host Controller Interface driver
[   14.870275] kmodloader: done loading kernel modules from /etc/modules-boot.d/                                                                                                 *
[   14.889946] init: - preinit -
[   15.127176] random: jshn: uninitialized urandom read (4 bytes read)
[   15.145955] random: jshn: uninitialized urandom read (4 bytes read)
[   15.159091] random: jshn: uninitialized urandom read (4 bytes read)
[   15.287306] meson8b-dwmac ff3f0000.ethernet eth0: no phy at addr -1
[   15.307658] meson8b-dwmac ff3f0000.ethernet eth0: stmmac_open: Cannot attach                                                                                                  to PHY (error: -19)
[   18.449085] mount_root: mounting /dev/root
[   18.471709] BTRFS info (device mmcblk1p2): disk space caching is enabled
[   18.482421] mount_root: loading kmods from internal overlay
[   18.692135] kmodloader: loading kernel modules from //etc/modules-boot.d/*
[   18.702952] kmodloader: done loading kernel modules from //etc/modules-boot.d                                                                                                 /*
[   19.051723] block: attempting to load /etc/config/fstab
[   19.062266] block: extroot: unable to determine root device
[   19.082179] urandom-seed: Seeding with /etc/urandom.seed
[   19.491165] procd: - early -
[   19.582667] urandom_read: 1 callbacks suppressed
[   19.582673] random: jshn: uninitialized urandom read (4 bytes read)
[   19.666296] random: jshn: uninitialized urandom read (4 bytes read)
[   19.727866] random: jshn: uninitialized urandom read (4 bytes read)
[   20.031069] procd: - ubus -
[   20.087433] procd: - init -
Please press Enter to activate this console.
[   20.267566] urngd: v1.0.2 started.
[   20.291743] crng init done
[   20.296167] random: 3 urandom warning(s) missed due to ratelimiting
[   20.410393] kmodloader: loading kernel modules from /etc/modules.d/*
[   20.428891] device-mapper: ioctl: 4.41.0-ioctl (2019-09-16) initialised: dm-d                                                                                                 evel@redhat.com
[   20.616682] Key type cifs.spnego registered
[   20.622204] Key type cifs.idmap registered
[   20.662121] RPC: Registered named UNIX socket transport module.
[   20.668153] RPC: Registered udp transport module.
[   20.673805] RPC: Registered tcp transport module.
[   20.678188] RPC: Registered tcp NFSv4.1 backchannel transport module.
[   20.694812] tun: Universal TUN/TAP device driver, 1.6
[   20.725277] ipip: IPv4 and MPLS over IPv4 tunneling driver
[   20.745223] Ethernet Channel Bonding Driver: v3.7.1 (April 27, 2011)
[   20.762042] FS-Cache: Netfs 'nfs' registered for caching
[   20.778497] Installing knfsd (copyright (C) 1996 okir@monad.swb.de).
[   20.800194] NFS: Registering the id_resolver key type
[   20.804059] Key type id_resolver registered
[   20.807803] Key type id_legacy registered
[   20.967696] cfg80211: Loading compiled-in X.509 certificates for regulatory d                                                                                                 atabase
[   21.242949] cfg80211: Loaded X.509 cert 'sforshee: 00b28ddf47aef9cea7'
[   21.312820] RTL871X: module init start
[   21.316450] RTL871X: rtl8189fs v4.3.24.8_22657.20170607
[   21.320067] RTL871X: module init ret=0
[   21.322499] FAT-fs (mmcblk1p1): Volume was not properly unmounted. Some data                                                                                                  may be corrupt. Please run fsck.
[   21.398329] usbcore: registered new interface driver ath6kl_usb
[   21.407883] hso: drivers/net/usb/hso.c: Option Wireless
[   21.411707] usbcore: registered new interface driver hso
[   21.418314] usbcore: registered new interface driver ipheth
[   21.424959] usbcore: registered new interface driver kaweth
[   21.429290] lib80211: common routines for IEEE802.11 drivers
[   21.452236] usbcore: registered new interface driver mt7601u
[   21.461093] usbcore: registered new interface driver mt76x2u
[   21.484645] pegasus: v0.9.3 (2013/04/25), Pegasus/Pegasus II USB Ethernet dri                                                                                                 ver
[   21.490097] usbcore: registered new interface driver pegasus
[   21.497167] usbcore: registered new interface driver r8152
[   21.503024] r8188eu: module is from the staging directory, the quality is unk                                                                                                 nown, you have been warned.
[   21.519292] usbcore: registered new interface driver r8188eu
[   21.524193] r8712u: module is from the staging directory, the quality is unkn                                                                                                 own, you have been warned.
[   21.534718] usbcore: registered new interface driver r8712u
[   21.540783] r8723bs: module is from the staging directory, the quality is unk                                                                                                 nown, you have been warned.
[   21.556295] RTL8723BS: module init start
[   21.560140] RTL8723BS: rtl8723bs v4.3.5.5_12290.20140916_BTCOEX20140507-4E40
[   21.565384] RTL8723BS: rtl8723bs BT-Coex version = BTCOEX20140507-4E40
[   21.571941] RTL8723BS: module init ret =0
[   21.581137] usbcore: registered new interface driver rt73usb
[   21.585813] usbcore: registered new interface driver rtl8150
[   21.592245] usbcore: registered new interface driver rtl8187
[   21.651989]
[   21.655650] =======================================================
[   21.659952] ==== Launching Wi-Fi driver! (Powered by Rockchip) ====
[   21.666156] =======================================================
[   21.672355] Realtek 8188FU USB WiFi driver (Powered by Rockchip) init.
[   21.678834] RTL871X: module init start
[   21.682540] RTL871X: rtl8188fu v4.3.23.6_20964.20170110
[   21.687879] usbcore: registered new interface driver rtl8188fu
[   21.693490] RTL871X: module init ret=0
[   21.700905] usbcore: registered new interface driver rtl8xxxu
[   21.707183] usbcore: registered new interface driver ums-alauda
[   21.711865] usbcore: registered new interface driver ums-cypress
[   21.717783] usbcore: registered new interface driver ums-datafab
[   21.723688] usbcore: registered new interface driver ums-freecom
[   21.729780] usbcore: registered new interface driver ums-isd200
[   21.735581] usbcore: registered new interface driver ums-jumpshot
[   21.741513] usbcore: registered new interface driver ums-karma
[   21.747373] usbcore: registered new interface driver ums-sddr09
[   21.753291] usbcore: registered new interface driver ums-sddr55
[   21.759142] usbcore: registered new interface driver ums-usbat
[   21.768287] usbcore: registered new device driver usbip-host
[   21.772727] usbcore: registered new interface driver usblp
[   21.782431] usbcore: registered new interface driver usbserial_generic
[   21.786639] usbserial: USB Serial support registered for generic
[   21.794747] vhci_hcd vhci_hcd.0: USB/IP Virtual Host Controller
[   21.798647] vhci_hcd vhci_hcd.0: new USB bus registered, assigned bus number                                                                                                  3
[   21.805661] vhci_hcd: created sysfs vhci_hcd.0
[   21.810143] usb usb3: New USB device found, idVendor=1d6b, idProduct=0002, bc                                                                                                 dDevice= 5.04
[   21.818140] usb usb3: New USB device strings: Mfr=3, Product=2, SerialNumber=                                                                                                 1
[   21.825308] usb usb3: Product: USB/IP Virtual Host Controller
[   21.830997] usb usb3: Manufacturer: Linux 5.4.182-flippy-70+o vhci_hcd
[   21.837464] usb usb3: SerialNumber: vhci_hcd.0
[   21.842283] hub 3-0:1.0: USB hub found
[   21.845615] hub 3-0:1.0: 8 ports detected
[   21.850308] vhci_hcd vhci_hcd.0: USB/IP Virtual Host Controller
[   21.855637] vhci_hcd vhci_hcd.0: new USB bus registered, assigned bus number                                                                                                  4
[   21.862661] usb usb4: We don't know the algorithms for LPM for this host, dis                                                                                                 abling LPM.
[   21.870678] usb usb4: New USB device found, idVendor=1d6b, idProduct=0003, bc                                                                                                 dDevice= 5.04
[   21.878805] usb usb4: New USB device strings: Mfr=3, Product=2, SerialNumber=                                                                                                 1
[   21.885957] usb usb4: Product: USB/IP Virtual Host Controller
[   21.891635] usb usb4: Manufacturer: Linux 5.4.182-flippy-70+o vhci_hcd
[   21.898100] usb usb4: SerialNumber: vhci_hcd.0
[   21.902978] hub 4-0:1.0: USB hub found
[   21.906342] hub 4-0:1.0: 8 ports detected
[   21.930195] xt_time: kernel timezone is -0000
[   21.935126] usbcore: registered new interface driver asix
[   21.946880] usbcore: registered new interface driver ax88179_178a
[   21.965866] Bluetooth: Core ver 2.22
[   21.969136] Bluetooth: Starting self testing
[   21.984990] Bluetooth: ECDH test passed in 12341 usecs
[   21.990487] Bluetooth: SMP test passed in 2119 usecs
[   21.993801] Bluetooth: Finished self testing
[   21.997368] NET: Registered protocol family 31
[   22.001697] Bluetooth: HCI device and connection manager initialized
[   22.008003] Bluetooth: HCI socket layer initialized
[   22.012835] Bluetooth: L2CAP socket layer initialized
[   22.017846] Bluetooth: SCO socket layer initialized
[   22.032279] usbcore: registered new interface driver brcmfmac
[   22.040915] bridge: filtering via arp/ip/ip6tables is no longer available by                                                                                                  default. Update your scripts to load br_netfilter if you need this.
[   22.055095] usbcore: registered new interface driver carl9170
[   22.059281] usbcore: registered new interface driver cdc_eem
[   22.065268] usbcore: registered new interface driver cdc_ether
[   22.071465] usbcore: registered new interface driver cdc_ncm
[   22.076139] usbcore: registered new interface driver cdc_subset
[   22.082104] usbcore: registered new interface driver ch341
[   22.086717] usbserial: USB Serial support registered for ch341-uart
[   22.094413] usbcore: registered new interface driver cp210x
[   22.098535] usbserial: USB Serial support registered for cp210x
[   22.105418] usbcore: registered new interface driver dm9601
[   22.110766] usbcore: registered new interface driver huawei_cdc_ncm
[   22.118937] usbcore: registered new interface driver kalmia
[   22.123071] usbcore: registered new interface driver MOSCHIP usb-ethernet dri                                                                                                 ver
[   22.133289] usbcore: registered new interface driver mt76x0u
[   22.139580] usbcore: registered new interface driver pl2303
[   22.142597] usbserial: USB Serial support registered for pl2303
[   22.149232] usbcore: registered new interface driver plusb
[   22.155674] PPP generic driver version 2.4.2
[   22.160270] NET: Registered protocol family 24
[   22.165013] usbcore: registered new interface driver qmi_wwan
[   22.169636] usbcore: registered new interface driver rndis_host
[   22.178160] usbcore: registered new interface driver RSI-USB WLAN
[   22.183211] usbcore: registered new interface driver rt2500usb
[   22.192972] usbcore: registered new interface driver rt2800usb
[   22.197569] usbcore: registered new interface driver sierra_net
[   22.203758] usbcore: registered new interface driver smsc95xx
[   22.208974] usbcore: registered new interface driver sr9700
[   22.221824] usbcore: registered new interface driver ath9k_htc
[   22.226145] Bridge firewalling registered
[   22.230499] usbcore: registered new interface driver cdc_mbim
[   22.238256] usbcore: registered new interface driver option
[   22.241475] usbserial: USB Serial support registered for GSM modem (1-port)
[   22.253695] kmodloader: done loading kernel modules from /etc/modules.d/*
[   26.737095] meson8b-dwmac ff3f0000.ethernet eth0: no phy at addr -1
[   26.742565] meson8b-dwmac ff3f0000.ethernet eth0: stmmac_open: Cannot attach                                                                                                  to PHY (error: -19)
[   26.750663] br-lan: port 1(eth0) entered blocking state
[   26.756604] br-lan: port 1(eth0) entered disabled state
[   26.764864] device eth0 entered promiscuous mode



BusyBox v1.33.2 (2022-03-02 12:29:32 UTC) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -------------------------------------------------------
 Install: OpenWrt → System → Amlogic Service → Install
 Update: OpenWrt → System → Amlogic Service → Update
 Amlogic SoC: s905l3a
 OpenWrt Kernel: 5.4.182-flippy-70+o
 Packaged Date: 2022-03-03
 -------------------------------------------------------
root@OpenWrt:/#


```